### PR TITLE
Allow dollar signs when parsing non-quoted values

### DIFF
--- a/Lib/glyphs2ufo/parser.py
+++ b/Lib/glyphs2ufo/parser.py
@@ -23,7 +23,7 @@ class Parser:
 
     def __init__(self, dict_type):
         self.dict_type = dict_type
-        value_re = r'(".*?(?<!\\)"|[-_./A-Za-z0-9]+)'
+        value_re = r'(".*?(?<!\\)"|[-_./$A-Za-z0-9]+)'
         self.start_dict_re = re.compile(r'\s*{')
         self.end_dict_re = re.compile(r'\s*}')
         self.dict_delim_re = re.compile(r'\s*;')


### PR DESCRIPTION
If there are `$`s in Glyphs tabs, they are stored as non-quoted values in .glyphs file, for example:  [dollar.glyphs](https://gist.github.com/mashabow/31b45622d8ce5d2f9c7c "dollar.glyphs"). But glyphs2ufo's parser fails to parse such .glyphs file.

This PR fixes it.