### PR TITLE
Warn about unrecognized weights in get_weight_code.

### DIFF
--- a/Lib/glyphs2ufo/torf.py
+++ b/Lib/glyphs2ufo/torf.py
@@ -427,9 +427,8 @@ def get_weight_code(style_name):
         'Black': 900
     }.get(style_name, None)
     if not weight_code:
-      print('WARNING: Unrecognized style name "%s"' % style_name,
-            file=sys.stderr)
-      weight_code = 400
+        warn('Unrecognized style name "%s"' % style_name)
+        weight_code = 400
     return weight_code
 
 
@@ -662,4 +661,4 @@ def add_features_to_rfont(rfont, feature_prefixes, classes, features):
 
 
 def warn(message):
-    print(message)
+    print('WARNING: ' + message, file=sys.stderr)

--- a/Lib/glyphs2ufo/torf.py
+++ b/Lib/glyphs2ufo/torf.py
@@ -16,6 +16,7 @@
 from __future__ import print_function, division, absolute_import
 
 import re
+import sys
 from robofab.world import RFont
 
 __all__ = [
@@ -411,15 +412,25 @@ def build_postscript_name(family_name, style_name):
 def get_weight_code(style_name):
     """Get the appropriate OS/2 weight code for this style."""
 
-    return {
+    weight_code = {
         'Thin': 250,
         'Light': 300,
+        'SemiLight': 350,
+        'DemiLight': 350,
+        '': 400,
+        'Regular': 400,
         'Medium': 500,
+        'DemiBold': 600,
         'SemiBold': 600,
         'Bold': 700,
         'ExtraBold': 800,
         'Black': 900
-    }.get(style_name, 400)
+    }.get(style_name, None)
+    if not weight_code:
+      print('WARNING: Unrecognized style name "%s"' % style_name,
+            file=sys.stderr)
+      weight_code = 400
+    return weight_code
 
 
 def get_width_code(style_name):


### PR DESCRIPTION
- Also support more weights, e.g. SemiLight, DemiLight, DemiBold,
  Regular, empty string (to handle cases where 'Italic' was removed
  leaving no weight-- defaults to Regular in this case).