### PR TITLE
Improve instance custom param handling

### DIFF
--- a/Lib/glyphs2ufo/casting.py
+++ b/Lib/glyphs2ufo/casting.py
@@ -86,7 +86,7 @@ def get_type_structure():
         'DisplayStrings': list,
         'classes': {
             'automatic': truthy,
-            'code': feature_syntax,
+            'code': normalized,
             'name': str
         },
         'copyright': str,
@@ -99,15 +99,15 @@ def get_type_structure():
         'familyName': str,
         'featurePrefixes': {
             'automatic': truthy,  # undocumented
-            'code': feature_syntax,
+            'code': normalized,
             'name': str
         },
         'features': {
             'automatic': truthy,
-            'code': feature_syntax,
+            'code': normalized,
             'disabled': truthy,  # undocumented
             'name': str,
-            'notes': feature_syntax  # undocumented
+            'notes': normalized  # undocumented
         },
         'fontMaster': {
             'alignmentZones': pointlist,
@@ -311,7 +311,7 @@ def version_minor(string):
     return num
 
 
-def feature_syntax(string):
+def normalized(string):
     """Replace escaped characters with their intended characters.
     Unescapes curved quotes to straight quotes, so that we can definitely
     include this casted data in feature syntax.
@@ -329,8 +329,10 @@ def custom_params(param_list):
     """Cast some known data in custom parameters."""
 
     for param in param_list:
-        name = param['name']
+        name = normalized(param['name'])
         value = param['value']
+
+        param['name'] = name
         if name in CUSTOM_INT_PARAMS:
             param['value'] = int(value)
         if name in CUSTOM_FLOAT_PARAMS:

--- a/Lib/glyphs2ufo/casting.py
+++ b/Lib/glyphs2ufo/casting.py
@@ -52,7 +52,8 @@ CUSTOM_FLOAT_PARAMS = frozenset((
     'postscriptBlueScale',))
 
 CUSTOM_TRUTHY_PARAMS = frozenset((
-    'isFixedPitch', 'postscriptForceBold', 'postscriptIsFixedPitch'))
+    'isFixedPitch', 'postscriptForceBold', 'postscriptIsFixedPitch',
+    'DisableAllAutomaticBehaviour'))
 
 CUSTOM_INTLIST_PARAMS = frozenset((
     'fsType', 'openTypeOS2CodePageRanges', 'openTypeOS2FamilyClass',
@@ -337,8 +338,6 @@ def custom_params(param_list):
             param['value'] = truthy(value)
         if name in CUSTOM_INTLIST_PARAMS:
             param['value'] = intlist(value)
-        elif name == 'DisableAllAutomaticBehaviour':
-            param['value'] = truthy(value)
 
     return param_list
 

--- a/Lib/glyphs2ufo/casting.py
+++ b/Lib/glyphs2ufo/casting.py
@@ -53,7 +53,7 @@ CUSTOM_FLOAT_PARAMS = frozenset((
 
 CUSTOM_TRUTHY_PARAMS = frozenset((
     'isFixedPitch', 'postscriptForceBold', 'postscriptIsFixedPitch',
-    'DisableAllAutomaticBehaviour'))
+    "Don't use Production Names", 'DisableAllAutomaticBehaviour'))
 
 CUSTOM_INTLIST_PARAMS = frozenset((
     'fsType', 'openTypeOS2CodePageRanges', 'openTypeOS2FamilyClass',

--- a/Lib/glyphs2ufo/casting.py
+++ b/Lib/glyphs2ufo/casting.py
@@ -57,7 +57,8 @@ CUSTOM_TRUTHY_PARAMS = frozenset((
 
 CUSTOM_INTLIST_PARAMS = frozenset((
     'fsType', 'openTypeOS2CodePageRanges', 'openTypeOS2FamilyClass',
-    'openTypeOS2Panose', 'openTypeOS2Type', 'openTypeOS2UnicodeRanges'))
+    'openTypeOS2Panose', 'openTypeOS2Type', 'openTypeOS2UnicodeRanges',
+    'panose'))
 
 
 def cast_data(data, types=None):

--- a/Lib/glyphs2ufo/interpolation.py
+++ b/Lib/glyphs2ufo/interpolation.py
@@ -21,7 +21,7 @@ from mutatorMath.ufo import build
 from mutatorMath.ufo.document import DesignSpaceDocumentWriter
 from robofab.world import OpenFont
 
-from glyphs2ufo.torf import set_redundant_data, clear_data, build_family_name, build_style_name, GLYPHS_PREFIX
+from glyphs2ufo.torf import set_redundant_data, set_custom_params, clear_data, build_family_name, build_style_name, GLYPHS_PREFIX
 
 __all__ = [
     'interpolate'
@@ -55,9 +55,7 @@ def interpolate(rfonts, master_dir, out_dir, designspace_path,
     instance_ufos = []
     for path, data in instance_files:
         ufo = OpenFont(path)
-        for attr in data:
-            if attr.pop('name') == 'panose':
-                ufo.info.openTypeOS2Panose = map(int, attr.pop('value'))
+        set_custom_params(ufo, data=data)
         set_redundant_data(ufo)
         instance_ufos.append(ufo)
 
@@ -103,9 +101,10 @@ def add_masters_to_writer(writer, rfonts):
 def add_instances_to_writer(writer, base_family, instances, italic, out_dir):
     """Add instances from Glyphs data to a MutatorMath document writer.
 
-    Returns a list of <ufo_path, custom_font_data> pairs, corresponding to the
-    instances which will be output by the document writer. The custom font data
-    is Glyphs customParameters data (a list of <attr_name, value> pairs)."""
+    Returns a list of <ufo_path, font_data> pairs, corresponding to the
+    instances which will be output by the document writer. The font data is the
+    Glyphs data for this instance as a dict.
+    """
 
     ofiles = []
     for instance in instances:
@@ -114,7 +113,7 @@ def add_instances_to_writer(writer, base_family, instances, italic, out_dir):
         style_name = build_style_name(instance, 'weightClass', italic)
         ufo_path = os.path.join(
             out_dir, build_postscript_name(family_name, style_name) + '.ufo')
-        ofiles.append((ufo_path, instance.get('customParameters', [])))
+        ofiles.append((ufo_path, instance))
 
         writer.startInstance(
             name=instance.pop('name'),

--- a/Lib/glyphs2ufo/interpolation.py
+++ b/Lib/glyphs2ufo/interpolation.py
@@ -57,6 +57,7 @@ def interpolate(rfonts, master_dir, out_dir, designspace_path,
         ufo = OpenFont(path)
         set_custom_params(ufo, data=data)
         set_redundant_data(ufo)
+        ufo.save()
         instance_ufos.append(ufo)
 
     if debug:


### PR DESCRIPTION
This allows more custom parameters to be loaded into instance UFOs, using the same code that loads them for masters.

Part of https://github.com/googlei18n/fontmake/issues/20 in that some of these custom parameters are used for filtering glyph output.