### PR TITLE
don't import defcon/mutatorMath in global scope

### DIFF
--- a/Lib/glyphs2ufo/builder.py
+++ b/Lib/glyphs2ufo/builder.py
@@ -20,8 +20,6 @@ import re
 import shutil
 import sys
 
-from defcon import Font
-
 __all__ = [
     'to_ufos', 'clear_data', 'set_redundant_data', 'set_custom_params',
     'build_style_name', 'build_ufo_path', 'write_ufo', 'GLYPHS_PREFIX'
@@ -178,6 +176,7 @@ def clear_data(data):
 
 def generate_base_fonts(data, italic):
     """Generate a list of UFOs with metadata loaded from .glyphs data."""
+    from defcon import Font
 
     date_created = to_ufo_time(data.pop('date'))
     family_name = data.pop('familyName')

--- a/Lib/glyphs2ufo/interpolation.py
+++ b/Lib/glyphs2ufo/interpolation.py
@@ -17,10 +17,6 @@ from __future__ import print_function, division, absolute_import
 
 import os
 
-from defcon import Font
-from mutatorMath.ufo import build
-from mutatorMath.ufo.document import DesignSpaceDocumentWriter
-
 from glyphs2ufo.builder import set_redundant_data, set_custom_params,\
     clear_data, build_style_name, write_ufo, build_ufo_path, GLYPHS_PREFIX
 
@@ -37,6 +33,8 @@ def interpolate(ufos, master_dir, out_dir, instance_data,
     """Create MutatorMath designspace and generate instances.
     Returns instance UFOs, or unused instance data if debug is True.
     """
+    from defcon import Font
+    from mutatorMath.ufo import build
 
     designspace_path, instance_files = build_designspace(
         ufos, master_dir, out_dir, instance_data, italic)
@@ -65,6 +63,7 @@ def build_designspace(masters, master_dir, out_dir, instance_data,
     (instance_path, instance_data) tuples which map instance UFO filenames to
     Glyphs data for that instance.
     """
+    from mutatorMath.ufo.document import DesignSpaceDocumentWriter
 
     for font in masters:
         write_ufo(font, master_dir)


### PR DESCRIPTION
glyphs2ufo should not require defcon or mutatorMath if a user just wants to parse a .glyphs file using `glyphs2ufo.glyphslib.load` or `loads` functions, but does not want to also dump it to ufo.